### PR TITLE
Bugfix/fos rest deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 
 
+## [2.0.2] - 2020-03-26
+### Added
+* support for fos rest bundle 3.0
+
+### Fixed
+* fos rest bundle >= 2.8 deprecation
+
+### Removed
+* dependency on fos-rest templating integration
+
 ## [2.0.1] - 2020-03-23
 ### Fixed
 * exception when mapping arrays of data

--- a/Handler/PhpViewHandler.php
+++ b/Handler/PhpViewHandler.php
@@ -2,12 +2,17 @@
 
 /** @noinspection PhpUnusedParameterInspection */
 
+declare(strict_types=1);
+
 namespace Shopping\ApiTKDtoMapperBundle\Handler;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandler;
+use Symfony\Component\Debug\Exception\FlattenException as LegacyFlattenException;
+use Symfony\Component\ErrorHandler\Exception\FlattenException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Throwable;
 
 /**
  * Class PhpViewHandler.
@@ -31,8 +36,14 @@ class PhpViewHandler
         $data = $view->getData();
 
         // Use simplified exception because serialization of closures inside the real exception is not allowed and crashes
-        if ($view->getTemplateVar() === 'raw_exception') {
-            $data = $view->getTemplateData()['exception'];
+        if ($data instanceof Throwable) {
+            // symfony/debug component was deprecated in symfony 4.4 and replaced by symfony/error-handler
+            // both of them are part of the standard framework-bundle which is required by this project so
+            // we can safely assume that one of them is present.
+            // to allow symfony 4.3 compatibility, use the FlattenException from symfony/debug when symfony/error-handler
+            // is not available
+            $flattenExceptionClass = !class_exists(FlattenException::class) ? FlattenException::class : LegacyFlattenException::class;
+            $data = $flattenExceptionClass::createFromThrowable($data, $view->getStatusCode(), $view->getHeaders());
         }
 
         return new Response(serialize($data), $view->getStatusCode() ?? 200, $view->getHeaders());

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "check24/apitk-dtomapper-bundle",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "license": "MIT",
   "type": "symfony-bundle",
   "description": "This bundle provides mapping helpers to map rest action to DTOs and render them serialized.",
@@ -37,7 +37,7 @@
     "doctrine/annotations": "^1.6",
     "nelmio/api-doc-bundle": "^3.2",
     "check24/apitk-common-bundle": "^2.0",
-    "friendsofsymfony/rest-bundle": "^2.3"
+    "friendsofsymfony/rest-bundle": ">= 2.3 <4.0"
   },
   "require-dev": {
     "captainhook/captainhook": "^5.0",

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,8 @@
   "require-dev": {
     "captainhook/captainhook": "^5.0",
     "captainhook/plugin-composer": "^5.1",
+    "symfony/debug": ">= 4.3 <6.0",
+    "symfony/error-handler": ">= 4.4 <6.0",
     "friendsofphp/php-cs-fixer": "^2.13",
     "phpmd/phpmd": "^2.6",
     "phpstan/phpstan": "^0.11.19"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7c32ca877602e08d59041bb901c64503",
+    "content-hash": "05b83d6d85bdca32944797bede1f9298",
     "packages": [
         {
             "name": "check24/apitk-common-bundle",
@@ -745,16 +745,16 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.2",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801"
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/446d54b4cb6bf489fc9d75f55843658e6f25d801",
-                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc",
                 "shasum": ""
             },
             "require": {
@@ -788,7 +788,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2019-11-01T11:05:21+00:00"
+            "time": "2020-03-23T09:12:05+00:00"
         },
         {
             "name": "sensio/framework-extra-bundle",


### PR DESCRIPTION
Removes usage of templating from our fos rest integration as it's deprecated in 2.8 and will be removed in 3.0

we're flattening exceptions ourselves instead

As a result, this bundle is now fos-rest 3.0 compatible so I bumped the version constraint in composer.json